### PR TITLE
Add DuckDuckGo to worthwhile mentions

### DIFF
--- a/index.html
+++ b/index.html
@@ -1483,6 +1483,9 @@
 				<a href="https://www.ixquick.eu/">ixquick.eu</a> - Returns the top ten results from multiple search engines. Based in the
 				USA and the Netherlands.
 			</li>
+			<li>
+				<a href="https://duckduckgo.com/">DuckDuckGo</a> - A private search engine that does not track you.
+			</li>
 		</ul>
 
 


### PR DESCRIPTION
I thought DDG would fit in the same list as other privacy focused search engines. Their privacy policy is simple enough for anyone to understand, but they are clear in the workings of the search engines.

https://duckduckgo.com/privacy